### PR TITLE
Fix duplicate key error in SongHistory

### DIFF
--- a/web/src/components/SongHistory.js
+++ b/web/src/components/SongHistory.js
@@ -8,7 +8,7 @@ function SongHistory({songs}) {
     <div className="scroller-wrap">
       <div className="song-history scroller">
         <h2>Song History</h2>
-        {songs.map(item => <SongHistoryItem key={item.song.uid} {...item} />)}
+        {songs.map(item => <SongHistoryItem key={item.startTime} {...item} />)}
       </div>
     </div>
   );


### PR DESCRIPTION
I think startTime is going to be unique enough.

Alternatives include:
- startTime and id concatenated (verbose, but less chance of conflict, but when will you ever play two songs in the same millisecond?)
- reverse index in array (will break with infinite scroll)